### PR TITLE
fix typo in pentesting-imap.md

### DIFF
--- a/network-services-pentesting/pentesting-imap.md
+++ b/network-services-pentesting/pentesting-imap.md
@@ -63,7 +63,7 @@ Or **automate** this with **nmap** plugin `imap-ntlm-info.nse`
 
 ## Syntax
 
-IAMP Commands examples from [here](https://donsutherland.org/crib/imap):
+IMAP Commands examples from [here](https://donsutherland.org/crib/imap):
 
 ```
 Login


### PR DESCRIPTION
Just a very small typo in pentesting-imap.md
